### PR TITLE
Fix PLAYER_PARTICIPATE_KILL_PLAYER to only trigger for assistants

### DIFF
--- a/src/main/java/com/ssomar/executableevents/events/player/custom/PlayerParticipateKillPlayerListener.java
+++ b/src/main/java/com/ssomar/executableevents/events/player/custom/PlayerParticipateKillPlayerListener.java
@@ -3,17 +3,22 @@ package com.ssomar.executableevents.events.player.custom;
 import com.ssomar.executableevents.events.EventsManager;
 import com.ssomar.executableevents.executableevents.activators.Option;
 import com.ssomar.score.sobject.sactivator.EventInfo;
-import com.ssomar.sevents.events.player.kill.entity.participate.player.PlayerParticipateKillEntityEvent;
 import com.ssomar.sevents.events.player.kill.player.participate.player.PlayerParticipateKillPlayerEvent;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-import java.util.ArrayList;
 import java.util.Optional;
 
 public class PlayerParticipateKillPlayerListener implements Listener {
     @EventHandler
     public void onPlayerParticipateKillPlayer(PlayerParticipateKillPlayerEvent e) {
+        // Skip if the participant is the killer (only process for assistants)
+        Player killer = e.getTarget().getKiller();
+        if (killer != null && killer.getUniqueId().equals(e.getPlayer().getUniqueId())) {
+            return;
+        }
+
         EventInfo eInfo = new EventInfo(e);
         eInfo.setPlayer(Optional.of(e.getPlayer()));
         eInfo.setTargetPlayer(Optional.of(e.getTarget()));


### PR DESCRIPTION
## Summary
- Modified `PLAYER_PARTICIPATE_KILL_PLAYER` activator to exclude the killer
- The activator now only fires for players who assisted in the kill
- Players who dealt the final blow (the killer) will not trigger this activator

## Changes
- Added a check in `PlayerParticipateKillPlayerListener` to skip processing if the participant is the killer
- Uses `e.getTarget().getKiller()` to determine the killer and compares it with the current participant

## Test plan
- [ ] Test that PLAYER_PARTICIPATE_KILL_PLAYER does not fire for the killer
- [ ] Test that PLAYER_PARTICIPATE_KILL_PLAYER still fires for all assistants who dealt damage but did not get the final blow
- [ ] Verify PLAYER_KILL_PLAYER still works correctly for the killer

🤖 Generated with [Claude Code](https://claude.com/claude-code)