### PR TITLE
feat: wire %shooter% placeholder in EE projectile activators (SSO-36)

### DIFF
--- a/src/main/java/com/ssomar/executableevents/executableevents/activators/ActivatorEEFeature.java
+++ b/src/main/java/com/ssomar/executableevents/executableevents/activators/ActivatorEEFeature.java
@@ -423,7 +423,7 @@ public class ActivatorEEFeature extends SActivator<ActivatorEEFeature, Activator
         if (playerOpt.isPresent()) {
             player = playerOpt.get();
             sp.setPlayerPlcHldr(player.getUniqueId(), 0);
-
+            if (projOpt.isPresent()) sp.setShooterPlcHldr(player.getUniqueId());
             defautlWorld = player.getWorld();
         }
         //SsomarDev.testMsg("Activator 4.6 >> "+player, DEBUG);


### PR DESCRIPTION
## Summary

- In `ActivatorEEFeature`, when a player is present and a projectile is present in the event context, calls `sp.setShooterPlcHldr(player.getUniqueId())`
- This makes `%shooter%` and `%shooter_*%` sub-variables available in EE projectile-related activators

Requires: SCore PR #183

Related: Paperclip SSO-36

🤖 Generated with [Claude Code](https://claude.com/claude-code)