### PR TITLE
Added missing method call for LEAVES_DECAY

### DIFF
--- a/src/main/java/com/ssomar/executableevents/events/block/custom/LeavesDecayListener.java
+++ b/src/main/java/com/ssomar/executableevents/events/block/custom/LeavesDecayListener.java
@@ -14,6 +14,7 @@ public class LeavesDecayListener implements Listener {
     public void onLeavesDecayEvent(LeavesDecayEvent e) {
         EventInfo eInfo = new EventInfo(e);
         eInfo.setBlock(Optional.of(e.getBlock()));
+        eInfo.setOldMaterialBlock(Optional.of(e.getBlock().getType()));
         eInfo.setOption(Option.LEAVES_DECAY);
         EventsManager.getInstance().activeOption(eInfo);
     }


### PR DESCRIPTION
Due to how block related activators behave, old material block info is required as well or else the activator will throw NullPointerException